### PR TITLE
feature: add a way to fetch template from the remote server

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,29 @@ Let's see three deployments with an `ansistrano_keep_releases: 2` configuration:
 
 See how the release `20100509145325` has been removed.
 
+Using templates files from remote hosts
+---------------------------------------
+
+During the `parameters` you can specify a list of template file to render `ansistrano_parameters_templates`.
+Those templates source path refered to the how who run the ansible playbook.
+
+To be able to get and use remote template you could use `ansistrano_fetch_remote_templates`.
+
+Usecase example : A template is provided in a git repository cloned on the remote host.
+We want to get the provided template on the host to render it.
+
+```
+# Get the template from the remote host
+ansistrano_fetch_remote_templates:
+  - dest: /tmp/play-application.conf.j2
+    src: "{{ansistrano_release_path.stdout}}/conf/application.conf.j2"
+
+# Then use this fetched template to configure the remote host
+ansistrano_parameters_templates:
+  - src: /tmp/play-application.conf.j2
+    dest: "{{ansistrano_release_path.stdout}}/conf/application.conf"
+```
+
 Example Playbook
 ----------------
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -115,3 +115,8 @@ aws_region: "eu-west-1"
 ansistrano_parameters_templates_directories: []
 # a list of map of config files
 ansistrano_parameters_templates: []
+
+# A list of map of config files to fetch from remote server
+ansistrano_fetch_remote_templates: []
+# Run once fetch remote tempplates
+ansistrano_fetch_remote_templates_run_once: true

--- a/tasks/fetch-remote-templates.yml
+++ b/tasks/fetch-remote-templates.yml
@@ -1,0 +1,11 @@
+---
+
+- name : fetch template from remote host
+  run_once: "{{ansistrano_fetch_remote_templates_run_once}}"
+  fetch:
+    src="{{ item.src }}"
+    dest="{{ item.dest }}"
+    flat=yes
+    fail_on_missing=yes
+  with_items: "{{ ansistrano_fetch_remote_templates }}"
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,6 +23,8 @@
 - include: update-code.yml
   when: not ansistrano_setup_only
 
+- include: fetch-remote-templates.yml
+
 - include: parameters.yml
 
 - include: "{{ ansistrano_after_update_code_tasks_file | default('empty.yml') }}"


### PR DESCRIPTION
ansistrano already allow to use templates with `ansistrano_parameters_templates` during the `parameters` step.

Those template are locally from the host who run the playbook.

This commit add a new step before `parameters` to be able to fetch template on the remote host `fetch-remote-templates`.

The usecase here is : Our customer provide the template of the configuration file in the git of his application in jinja format.
With this feature we are able to use the configuration template provided in the application code and render it.

Ex of usage :

```
      ansistrano_fetch_remote_templates:
        - dest: /tmp/play-application.conf.j2
          src: "{{ansistrano_release_path.stdout}}/conf/application.conf.j2"

      # Then use this fetched template to configure the server
      ansistrano_parameters_templates:
        - src: /tmp/play-application.conf.j2
          dest: "{{ansistrano_release_path.stdout}}/conf/application.conf"
```