### PR TITLE
slack: add icon & headline options

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -84,6 +84,8 @@ ansistrano_allow_anonymous_stats: no
 
 slack_token: ""
 slack: false
+slack_headline: ""
+slack_icon_url: ""
 
 # Handler flag
 ansistrano_supervisord_enabled: false

--- a/tasks/slack.yml
+++ b/tasks/slack.yml
@@ -11,6 +11,8 @@
     module: slack
     domain: cycloid-io.slack.com
     token: "{{ slack_token }}"
+    username: "{{ slack_headline }}"
+    icon_url: "{{ slack_icon_url }}"
     channel: "{{ slack_channel }}"
     msg: "{{ state }} - Deploy of {{ slack_title }} - server: {{ ansible_hostname}}, ts:{{ ansistrano_timestamp.stdout }}, env: {{ env }}, application: {{ ansistrano_app_name }}"
   ignore_errors: yes


### PR DESCRIPTION
If those options are set - as this is by default, slack will use its
webhook configuration to set an image and a headline. Otherwise Ansible
can overide this with whatever headlind and/or icon desired.