### PR TITLE
supervisor: refactoring for ansible2.7 broke this task

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,8 +4,8 @@
      state: start
   when: slack
 
-- supervisorctl: name={{ item }}
-  vars:
+- supervisorctl:
+     name: "{{ item }}"
      state: stopped
   when: ansistrano_supervisord_enabled and not ansistrano_supervisord_restart_only
   with_items: "{{ ansistrano_supervisord_programs }}"


### PR DESCRIPTION
The supervisorctl task received the same modifications than the
include_task instruction. However doing this, result in the required
'state' variable not being defined, and making the playbook fail.